### PR TITLE
add case modifier lambdas and add generic override to API template

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -4,6 +4,7 @@ import io.swagger.codegen.CodegenModel;
 import io.swagger.codegen.CodegenOperation;
 import io.swagger.codegen.CodegenProperty;
 import io.swagger.codegen.SupportingFile;
+import io.swagger.codegen.mustache.TitlecaseLambda;
 import io.swagger.models.ModelImpl;
 
 import java.io.File;
@@ -37,6 +38,7 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
     public void processOpts() {
         super.processOpts();
         supportingFiles.add(new SupportingFile("axios.config.mustache", "axios.config.ts"));
+        additionalProperties.put("titlecase", new TitlecaseLambda());
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/mustache/IndentedLambda.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/mustache/IndentedLambda.java
@@ -1,0 +1,93 @@
+package io.swagger.codegen.mustache;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * This naively prepends indention to all lines of a fragment.
+ * <p>
+ * Generator authors may add helpers for explicitly adding prefixed spaces which fragments won't be aware of.
+ * <p>
+ * Register:
+ * <pre>
+ * additionalProperties.put("indent4", new IndentedLambda(4));
+ * additionalProperties.put("indent8", new IndentedLambda(8));
+ * </pre>
+ * <p>
+ * Use:
+ * <pre>{@code
+ *     {{#indent4}}{{>template}}{{/indent4}}
+ *         {{#indent8}}{{>other_template}}{{/indent8}}
+ * }</pre>
+ */
+public class IndentedLambda implements Mustache.Lambda {
+    private final int prefixSpaceCount;
+    private int spaceCode;
+
+    /**
+     * Constructs a new instance of {@link IndentedLambda}, with an indent count of 4 spaces
+     */
+    public IndentedLambda() {
+        this(4, " ");
+    }
+
+    /**
+     * Constructs a new instance of {@link IndentedLambda}, with customized indent count and intention character
+     *
+     * @param prefixSpaceCount   The number of indented characters to apply as a prefix to a fragment.
+     * @param indentionCharacter String representation of the character used in the indent (e.g. " ", "\t", ".").
+     */
+    public IndentedLambda(int prefixSpaceCount, String indentionCharacter) {
+        this(prefixSpaceCount, Character.codePointAt(indentionCharacter, 0));
+    }
+
+    /**
+     * Constructs a new instance of {@link IndentedLambda}
+     *
+     * @param prefixSpaceCount The number of indented characters to apply as a prefix to a fragment.
+     */
+    private IndentedLambda(int prefixSpaceCount, int indentionCodePoint) {
+        if (prefixSpaceCount <= 0) {
+            throw new IllegalArgumentException("prefixSpaceCount must be greater than 0");
+        }
+
+        if (!Character.isValidCodePoint(indentionCodePoint)) {
+            throw new IllegalArgumentException("indentionCodePoint is an invalid code point ");
+        }
+
+        this.prefixSpaceCount = prefixSpaceCount;
+        this.spaceCode = indentionCodePoint;
+    }
+
+    @Override
+    public void execute(Template.Fragment fragment, Writer writer) throws IOException {
+        String text = fragment.execute();
+        if (text == null || text.length() == 0) {
+            return;
+        }
+
+        String prefixedIndention = StringUtils.repeat(new String(Character.toChars(spaceCode)), prefixSpaceCount);
+        StringBuilder sb = new StringBuilder();
+        String[] lines = text.split(System.lineSeparator());
+        for (int i = 0; i < lines.length; i++) {
+            String line = lines[i];
+            // Mustache will apply correct indentation to the first line of a template (to match declaration location).
+            // So, we want to skip the first line.
+            if (i > 0) {
+                sb.append(prefixedIndention);
+            }
+
+            sb.append(line);
+
+            // We've split on the system's line separator. We don't want to add an additional trailing line.
+            if (i < lines.length - 1) {
+                sb.append(System.lineSeparator());
+            }
+        }
+        writer.write(sb.toString());
+    }
+}

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/mustache/LowercaseLambda.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/mustache/LowercaseLambda.java
@@ -1,0 +1,44 @@
+package io.swagger.codegen.mustache;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+import io.swagger.codegen.CodegenConfig;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Converts text in a fragment to lowercase.
+ *
+ * Register:
+ * <pre>
+ * additionalProperties.put("lowercase", new LowercaseLambda());
+ * </pre>
+ *
+ * Use:
+ * <pre>
+ * {{#lowercase}}{{httpMethod}}{{/lowercase}}
+ * </pre>
+ */
+public class LowercaseLambda implements Mustache.Lambda {
+    private CodegenConfig generator = null;
+
+    public LowercaseLambda() {
+
+    }
+
+    public LowercaseLambda generator(final CodegenConfig generator) {
+        this.generator = generator;
+        return this;
+    }
+
+    @Override
+    public void execute(Template.Fragment fragment, Writer writer) throws IOException {
+        String text = fragment.execute().toLowerCase();
+        if (generator != null && generator.reservedWords().contains(text)) {
+            text = generator.escapeReservedWord(text);
+        }
+        writer.write(text);
+
+    }
+}

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/mustache/TitlecaseLambda.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/mustache/TitlecaseLambda.java
@@ -1,0 +1,68 @@
+package io.swagger.codegen.mustache;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Converts text in a fragment to title case.
+ *
+ * Register:
+ * <pre>
+ * additionalProperties.put("titlecase", new TitlecaseLambda());
+ * </pre>
+ *
+ * Use:
+ * <pre>
+ * {{#titlecase}}{{classname}}{{/titlecase}}
+ * </pre>
+ */
+public class TitlecaseLambda implements Mustache.Lambda  {
+    private String delimiter;
+
+    /**
+     * Constructs a new instance of {@link TitlecaseLambda}, which will convert all text
+     * in a space delimited string to title-case.
+     */
+    public TitlecaseLambda() {
+        this(" ");
+    }
+
+    /**
+     * Constructs a new instance of {@link TitlecaseLambda}, splitting on the specified
+     * delimiter and converting each word to title-case.
+     *
+     * NOTE: passing {@code null} results in a title-casing the first word only.
+     *
+     * @param delimiter Provided to allow an override for the default space delimiter.
+     */
+    public TitlecaseLambda(String delimiter) {
+        this.delimiter = delimiter;
+    }
+
+    private String titleCase(final String input) {
+        return input.substring(0, 1).toUpperCase() + input.substring(1);
+    }
+
+    @Override
+    public void execute(Template.Fragment fragment, Writer writer) throws IOException {
+        String text = fragment.execute();
+        if (delimiter == null) {
+            writer.write(titleCase(text));
+            return;
+        }
+
+        // Split accepts regex. \Q and \E wrap the delimiter to create a literal regex,
+        // so things like "." and "|" aren't treated as their regex equivalents.
+        String[] parts = text.split("\\Q" + delimiter + "\\E");
+        for (int i = 0; i < parts.length; i++) {
+            String part = parts[i];
+            writer.write(titleCase(part));
+            if (i != parts.length - 1) {
+                writer.write(delimiter);
+            }
+        }
+    }
+}

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/mustache/UppercaseLambda.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/mustache/UppercaseLambda.java
@@ -1,0 +1,28 @@
+package io.swagger.codegen.mustache;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Converts text in a fragment to uppercase.
+ *
+ * Register:
+ * <pre>
+ * additionalProperties.put("uppercase", new UppercaseLambda());
+ * </pre>
+ *
+ * Use:
+ * <pre>
+ * {{#uppercase}}{{summary}}{{/uppercase}}
+ * </pre>
+ */
+public class UppercaseLambda implements Mustache.Lambda {
+    @Override
+    public void execute(Template.Fragment fragment, Writer writer) throws IOException {
+        String text = fragment.execute();
+        writer.write(text.toUpperCase());
+    }
+}

--- a/modules/swagger-codegen/src/main/resources/typescript-axios/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-axios/api.mustache
@@ -25,7 +25,32 @@ export class {{classname}}Resource {
      * {{notes}}
      {{#allParams}}* @param {{paramName}} {{description}}
      {{/allParams}}*/
-    public {{nickname}}({{#allParams}}{{^isQueryParam}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/isQueryParam}}{{/allParams}}{{#hasQueryParams}}query?: { {{#queryParams}}{{paramName}}{{^required}}?{{/required}}: {{dataType}}{{^-last}},{{/-last}} {{/queryParams}}}, {{/hasQueryParams}}axiosConfig?: AxiosRequestConfig): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
+    public {{nickname}}
+        {{#allParams.0}}<{{/allParams.0}}
+        {{#allParams}}
+            {{^isQueryParam}}
+                {{#titlecase}}{{paramName}}{{/titlecase}} = Partial<{{{dataType}}}>{{^-last}},{{/-last}}
+            {{/isQueryParam}}
+        {{/allParams}}
+        {{#hasQueryParams}}
+            Query = { {{#queryParams}}{{paramName}}{{^required}}?{{/required}}: {{dataType}}{{^-last}},{{/-last}} {{/queryParams}}}{{^-last}},{{/-last}}
+        {{/hasQueryParams}}
+        {{#allParams.0}}>{{/allParams.0}}(
+        {{! Partialize all non query param args by default}}
+        {{#allParams}}
+            {{^isQueryParam}}
+                {{paramName}}{{^required}}?{{/required}}: {{#titlecase}}{{paramName}}{{/titlecase}},
+            {{/isQueryParam}}
+        {{/allParams}}
+
+        {{! query param }}
+        {{#hasQueryParams}}
+            query?: Query,
+        {{/hasQueryParams}}
+
+        axiosConfig?: AxiosRequestConfig
+    ): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
+
         const reqPath = '{{path}}'{{#pathParams}}
                     .replace('{' + '{{baseName}}}', String({{paramName}}{{#isDateTime}}.toISOString(){{/isDateTime}})){{/pathParams}};
 {{#hasFormParams}}


### PR DESCRIPTION
I took this idea from https://github.com/dotansimha/graphql-code-generator. It's a nice way to provide an override mechanism for the generated arguments to our resource functions.

Here's an example of the output.

```
public createCustomerWithProject<Body = Partial<ProjectWithCustomerRequest>>(
    body?: Body,
    axiosConfig?: AxiosRequestConfig
  ): Promise<ProjectWithCustomerRequest> {
    const reqPath = '/v1/customer/project';
    let reqConfig = {
      ...axiosConfig,
      method: 'POST',
      url: reqPath,
      data: body,
    };
    return axios.request(reqConfig).then(res => {
      return res.data;
    });
  }
```

These keeps our current functionality as is but allows for us to override if needed.