### PR TITLE
Remove unnecessary partial from params

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-axios/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-axios/api.mustache
@@ -29,7 +29,7 @@ export class {{classname}}Resource {
         {{#allParams.0}}<{{/allParams.0}}
         {{#allParams}}
             {{^isQueryParam}}
-                {{#titlecase}}{{paramName}}{{/titlecase}} = Partial<{{{dataType}}}>{{^-last}},{{/-last}}
+                {{#titlecase}}{{paramName}}{{/titlecase}} = {{{dataType}}}{{^-last}},{{/-last}}
             {{/isQueryParam}}
         {{/allParams}}
         {{#hasQueryParams}}


### PR DESCRIPTION
With the addition of generated `Update` models, we no longer need to partialize all query params.